### PR TITLE
chore(release): configure semantic-release rules and changelog format

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: "✨ Features"
+      labels:
+        - "type: feature"
+        - "type: enhancement"
+    - title: "🐛 Bug Fixes"
+      labels:
+        - "type: bug"
+        - "type: fix"
+    - title: "⚡ Performance Improvements"
+      labels:
+        - "type: performance"
+    - title: "⏪ Reverts"
+      labels:
+        - "type: revert"
+    - title: "📚 Documentation"
+      labels:
+        - "type: docs"
+        - "type: documentation"
+    - title: "♻️ Refactoring"
+      labels:
+        - "type: refactor"
+    - title: "🔧 Maintenance"
+      labels:
+        - "type: chore"
+        - "type: build"
+        - "type: ci"
+        - "type: dependencies"
+        - "dependencies"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,12 +7,38 @@
 	],
 	"plugins": [
 		[
-		  "@semantic-release/commit-analyzer",
-		  {
-			"preset": "conventionalcommits"
-		  }
+			"@semantic-release/commit-analyzer",
+			{
+				"preset": "conventionalcommits",
+				"releaseRules": [
+					{ "type": "feat", "release": "minor" },
+					{ "type": "fix", "release": "patch" },
+					{ "type": "perf", "release": "patch" },
+					{ "type": "revert", "release": "patch" },
+					{ "breaking": true, "release": "major" }
+				]
+			}
 		],
-		"@semantic-release/release-notes-generator",
+		[
+			"@semantic-release/release-notes-generator",
+			{
+				"preset": "conventionalcommits",
+				"presetConfig": {
+					"types": [
+						{ "type": "feat", "section": "✨ Features", "hidden": false },
+						{ "type": "fix", "section": "🐛 Bug Fixes", "hidden": false },
+						{ "type": "perf", "section": "⚡ Performance Improvements", "hidden": false },
+						{ "type": "revert", "section": "⏪ Reverts", "hidden": false },
+						{ "type": "docs", "section": "📚 Documentation", "hidden": false },
+						{ "type": "refactor", "section": "♻️ Refactoring", "hidden": false },
+						{ "type": "test", "section": "✅ Tests", "hidden": true },
+						{ "type": "build", "section": "📦 Build System", "hidden": true },
+						{ "type": "ci", "section": "👷 CI", "hidden": true },
+						{ "type": "chore", "section": "🔧 Maintenance", "hidden": true }
+					]
+				}
+			}
+		],
 		[
 			"@semantic-release/changelog",
 			{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,10 @@
-# 1.0.0 (2026-03-26)
+# Changelog
 
-### Features
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-- initial commit of @allons-y/envoy ([3f2779d](https://github.com/castastrophe/envoy/commit/3f2779db831ad97f1dd07a636d329a531c499f92))
-- initial commit of @allons-y/envoy ([24cd6ba](https://github.com/castastrophe/envoy/commit/24cd6baa8033ad62703598aa6a4e2ff8e0f9835f))
-- **mcp:** export copyEnvToolHandler and add unit tests ([1182b5f](https://github.com/castastrophe/envoy/commit/1182b5f903d0a659f86f697e5921d9a86028693f))
+## [1.0.0](https://github.com/castastrophe/envoy/releases/tag/v1.0.0) (2026-03-26)
 
-# 1.0.0 (2026-03-26)
+### ✨ Features
 
-### Features
-
-- initial commit of @allons-y/envoy ([3f2779d](https://github.com/castastrophe/envoy/commit/3f2779db831ad97f1dd07a636d329a531c499f92))
-- initial commit of @allons-y/envoy ([24cd6ba](https://github.com/castastrophe/envoy/commit/24cd6baa8033ad62703598aa6a4e2ff8e0f9835f))
-- **mcp:** export copyEnvToolHandler and add unit tests ([1182b5f](https://github.com/castastrophe/envoy/commit/1182b5f903d0a659f86f697e5921d9a86028693f))
+- initial release of `@allons-y/envoy` — CLI, MCP server, and core `copyEnv` library ([3f2779d](https://github.com/castastrophe/envoy/commit/3f2779db831ad97f1dd07a636d329a531c499f92))
+- **mcp:** export `copyEnvToolHandler` for direct unit testing; register as named tool handler ([1182b5f](https://github.com/castastrophe/envoy/commit/1182b5f903d0a659f86f697e5921d9a86028693f))


### PR DESCRIPTION
## Summary

- Add explicit `releaseRules` to `commit-analyzer` so `feat`/`fix`/`perf`/`revert` map to the correct semver bump
- Wire up `release-notes-generator` with emoji section headers matching the new `.github/release.yml` categories
- Update `CHANGELOG.md` to the generated format for consistency

## Test plan

- [x] Verify semantic-release dry-run picks up the correct bump type for each commit type
- [x] Confirm GitHub release notes render the emoji section headers correctly
- [x] Check that `CHANGELOG.md` format matches what semantic-release will generate going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)