### PR TITLE
chore: add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Something isn't working as expected
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a bug report, please [search existing issues](https://github.com/castastrophe/envoy/issues) to avoid duplicates.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear summary of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: The exact steps needed to trigger the bug.
+      placeholder: |
+        1. Run `envoy --force` in a directory that contains...
+        2. Observe that...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include any error output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Fill in the relevant details.
+      value: |
+        - envoy version:
+        - Node.js version:
+        - Package manager + version:
+        - OS:
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help — screenshots, related issues, workarounds you've tried.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Roadmap & feature discussions
+    url: https://github.com/castastrophe/envoy/discussions/12
+    about: Check what's already planned or propose a new idea before opening an issue.
+  - name: Q&A / general help
+    url: https://github.com/castastrophe/envoy/discussions
+    about: Ask questions or discuss usage in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Propose a new feature or enhancement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a feature request, please check the [roadmap discussion](https://github.com/castastrophe/envoy/discussions/12) and [existing issues](https://github.com/castastrophe/envoy/issues) — your idea may already be planned or in progress.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What gap or pain point does this address? Be specific about the scenario.
+      placeholder: When I run envoy in a monorepo with...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe what you'd like envoy to do. Include any CLI flags, config syntax, or output you have in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about or tried.
+    validations:
+      required: false
+
+  - type: textarea
+    id: questions
+    attributes:
+      label: Open questions
+      description: Any edge cases or design decisions that aren't obvious.
+    validations:
+      required: false


### PR DESCRIPTION
Adds YAML-based issue form templates so contributors get a structured
experience when opening bugs or feature requests. config.yml disables
blank issues and surfaces the roadmap discussion and Q&A as contact links.

https://claude.ai/code/session_01WjowNzrhZSjeuKCen5wbEe