### PR TITLE
chore: update domain from allons-y.llc to allons-y.studio

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at <consulting@allons-y.llc>. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at <report@allons-y.studio>. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "1.1.0",
 	"description": "Copies values from a root .env into a project .env using .env.example as a template",
 	"license": "MPL-2.0",
-	"author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)",
+	"author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.studio)",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Allons-y-Studio/envoy.git"


### PR DESCRIPTION
## What
Update domain references from `allons-y.llc` to `allons-y.studio`.

## Why
Studio rebrand — the `.llc` domain is being retired in favour of `.studio`.

## How
Find-and-replace author URL in `package.json`; update enforcement email in `.github/CODE_OF_CONDUCT.md`.

## Test plan
Verified no remaining `allons-y.llc` references in source files (excluding `.git` and `node_modules`).

## Checklist
- [x] My code follows the project's style and conventions.
- [x] I have performed a self-review of my changes.
- [ ] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] My changes generate no new warnings or accessibility regressions.
- [x] I have read the [Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).
