### PR TITLE
fix: restore Apache-2.0 license declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"name": "@allons-y/envoy",
 	"version": "1.1.0",
 	"description": "Copies values from a root .env into a project .env using .env.example as a template",
-	"license": "MPL-2.0",
+	"license": "Apache-2.0",
 	"author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.studio)",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

`package.json` listed the wrong license; should be `Apache-2.0`.

The stray `MPL-2.0` value was introduced in #24 during a reformat of `package.json` unintentionally.

No changes needed to `LICENSE` or `README.md`; both already state Apache 2.0, and the README's `allons-y.studio` link style is preserved.